### PR TITLE
36 upgrade pawn closes #36

### DIFF
--- a/lib/piece.js
+++ b/lib/piece.js
@@ -12,6 +12,13 @@ Piece.prototype.move = function (square) {
   this.square = square;
   square.piece = this;
   this.moveCount++;
+  if (square.piece.type === "pawn" && square.yCoordinate === square.piece.promotionLine) {
+    do {
+      var response = prompt("What type of piece do you want?", "q");
+    } while (!response === "q" || !response === "k" || !response === "b" || !response === "r") {
+      square.piece.promote.call (square.piece, response);
+    }
+  }
   this.square.board.nextTurn = true;
   this.square.board.game.toggleTurn();
 };

--- a/lib/piece.js
+++ b/lib/piece.js
@@ -15,9 +15,7 @@ Piece.prototype.move = function (square) {
   if (square.piece.type === "pawn" && square.yCoordinate === square.piece.promotionLine) {
     do {
       var response = prompt("What type of piece do you want?", "q");
-    } while (!response === "q" || !response === "k" || !response === "b" || !response === "r") {
-      response = prompt("What type of piece do you want?", "q");
-    }
+    } while (!response === "q" || !response === "k" || !response === "b" || !response === "r");
     square.piece.promote.call (square.piece, response);
   }
   this.square.board.nextTurn = true;

--- a/lib/piece.js
+++ b/lib/piece.js
@@ -16,8 +16,9 @@ Piece.prototype.move = function (square) {
     do {
       var response = prompt("What type of piece do you want?", "q");
     } while (!response === "q" || !response === "k" || !response === "b" || !response === "r") {
-      square.piece.promote.call (square.piece, response);
+      response = prompt("What type of piece do you want?", "q");
     }
+    square.piece.promote.call (square.piece, response);
   }
   this.square.board.nextTurn = true;
   this.square.board.game.toggleTurn();

--- a/lib/pieces/bishop.js
+++ b/lib/pieces/bishop.js
@@ -7,6 +7,7 @@ function Bishop (square, color) {
   } else {
     this.src = '../icons/standard/black-bishop.png';
   }
+  this.type = "bishop";
   this.vectors = { ne: [1,-1], se: [1,1], sw: [-1,1], nw: [-1,-1] }
 }
 

--- a/lib/pieces/knight.js
+++ b/lib/pieces/knight.js
@@ -7,6 +7,7 @@ function Knight (square, color) {
   } else {
     this.src = '../icons/standard/black-knight.png'
   }
+  this.type = "knight";
 }
 
 Knight.prototype = Object.create(Piece.prototype);

--- a/lib/pieces/pawn.js
+++ b/lib/pieces/pawn.js
@@ -1,4 +1,8 @@
 var Piece = require('../piece');
+var Rook = require('./rook');
+var Bishop = require('./bishop');
+var Queen = require('./queen');
+var Knight = require('./knight');
 
 function Pawn (square, color) {
   Piece.call(this, square, color);
@@ -9,6 +13,8 @@ function Pawn (square, color) {
     this.src = '../icons/standard/black-pawn.png';
     this.direction = 1;
   }
+  this.type = "pawn";
+  this.promotionLine = setPromotionLine(square);
 }
 
 Pawn.prototype = Object.create(Piece.prototype);
@@ -16,6 +22,33 @@ Pawn.prototype = Object.create(Piece.prototype);
 Pawn.prototype.canMoveTo = function (targetSquare) {
   return (canMoveForward(this, targetSquare) || canTakeDiagonally(this, targetSquare))
     && this.wontPutOwnKingInCheck(this, targetSquare);
+};
+
+Pawn.prototype.promote = function (value) {
+  var promoted;
+  switch (value) {
+    case "q":
+      promoted = new Queen (this.square, value.color);
+      break;
+    case "r":
+      promoted = new Rook (this.square, value.color);
+      break;
+    case "b":
+      promoted = new Bishop (this.square, value.color);
+      break;
+    case "k":
+      promoted = new Knight (this.square, value.color);
+      break;
+  }
+  this.square.piece = promoted;
+};
+
+function setPromotionLine(square) {
+  if (square.yCoordinate + 6 == 7) {
+    return square.yCoordinate + 6;
+  } else if (square.yCoordinate - 6 == 0) {
+    return square.yCoordinate - 6;
+  }
 };
 
 function canMoveForward (pawn, targetSquare) {

--- a/lib/pieces/pawn.js
+++ b/lib/pieces/pawn.js
@@ -28,16 +28,16 @@ Pawn.prototype.promote = function (value) {
   var promoted;
   switch (value) {
     case "q":
-      promoted = new Queen (this.square, value.color);
+      promoted = new Queen (this.square, this.color);
       break;
     case "r":
-      promoted = new Rook (this.square, value.color);
+      promoted = new Rook (this.square, this.color);
       break;
     case "b":
-      promoted = new Bishop (this.square, value.color);
+      promoted = new Bishop (this.square, this.color);
       break;
     case "k":
-      promoted = new Knight (this.square, value.color);
+      promoted = new Knight (this.square, this.color);
       break;
   }
   this.square.piece = promoted;

--- a/lib/pieces/queen.js
+++ b/lib/pieces/queen.js
@@ -7,8 +7,9 @@ function Queen (square, color) {
   } else {
     this.src = '../icons/standard/black-queen.png';
   }
+  this.type = "queen";
   this.vectors = {ne: [1,-1], se: [1,1], sw: [-1,1], nw: [-1,-1],
-    n: [0,-1], e: [1,0], s: [0, 1], w: [-1,0]}
+    n: [0,-1], e: [1,0], s: [0, 1], w: [-1,0]};
 }
 
 Queen.prototype = Object.create(Piece.prototype);

--- a/lib/pieces/rook.js
+++ b/lib/pieces/rook.js
@@ -7,6 +7,7 @@ function Rook (square, color) {
   } else {
     this.src = '../icons/standard/black-rook.png';
   }
+  this.type = "rook";
   this.vectors = {n: [0,-1], e: [1,0], s: [0, 1], w: [-1,0]};
 }
 

--- a/test/pieces/pawn-test.js
+++ b/test/pieces/pawn-test.js
@@ -7,6 +7,7 @@ var Square = require('../../lib/square')
 var Piece = require('../../lib/piece')
 var Pawn = require('../../lib/pieces/pawn')
 var King = require('../../lib/pieces/king')
+var Queen = require('../../lib/pieces/queen')
 
 describe('Pawn', function () {
 
@@ -134,6 +135,19 @@ describe('Pawn', function () {
 
     assert.equal(this.blackPawn.canMoveTo(squareTwo), false);
     assert.equal(this.blackPawn.canMoveTo(squareThree), false);
+  });
+
+  it('white pawn should be given an option to be promoted when it reaches the opponents 8th row.', function () {
+    let squareTwo = this.board.findSquare(5, 6);
+    let promotionSquare = this.board.findSquare(5, 7);
+    let pawn = new Pawn (squareTwo, "white");
+    pawn.moveCount = 1;
+    pawn.promotionLine = 7;
+    squareTwo.piece = pawn;
+
+    pawn.move(promotionSquare);
+
+    assert.equal(promotionSquare.piece.type, "queen");
   });
 
 });

--- a/test/pieces/pawn-test.js
+++ b/test/pieces/pawn-test.js
@@ -148,6 +148,7 @@ describe('Pawn', function () {
     pawn.move(promotionSquare);
 
     assert.equal(promotionSquare.piece.type, "queen");
+    assert.equal(promotionSquare.piece.color, "white");
   });
 
   it('black pawn should be given an option to be promoted when it reaches the opponents 8th row.', function () {
@@ -162,5 +163,6 @@ describe('Pawn', function () {
     pawn.move(promotionSquare);
 
     assert.equal(promotionSquare.piece.type, "queen");
+    assert.equal(promotionSquare.piece.color, "black");
   });
 });

--- a/test/pieces/pawn-test.js
+++ b/test/pieces/pawn-test.js
@@ -150,4 +150,17 @@ describe('Pawn', function () {
     assert.equal(promotionSquare.piece.type, "queen");
   });
 
+  it('black pawn should be given an option to be promoted when it reaches the opponents 8th row.', function () {
+    let squareTwo = this.board.findSquare(3, 1);
+    let promotionSquare = this.board.findSquare(3, 0);
+    let pawn = new Pawn (squareTwo, "black");
+    this.game.turn = "black";
+    pawn.moveCount = 1;
+    pawn.promotionLine = 0;
+    squareTwo.piece = pawn;
+
+    pawn.move(promotionSquare);
+
+    assert.equal(promotionSquare.piece.type, "queen");
+  });
 });


### PR DESCRIPTION
This PR creates the functionality for a pawn to be promoted whenever it reaches the opponents side.

The way this works is that depending on the color of the piece we give it a different promotion line (which is just the 8th rank opposite their starting position).

Then when a piece is moved we give a prompt to upgrade the piece.
