### PR TITLE
board returns to mousemove listener if clicked on invalid square

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -216,6 +216,7 @@ Board.prototype.makeBoardClickable = function () {
       board.canvas.addEventListener("mousedown", selectPiece);
     } else {
       flashRed(board, targetSquare);
+      board.canvas.addEventListener("mousemove", displayMoves);
     }
   }
 


### PR DESCRIPTION
previously it would show red and you would have to move off the canvas in order to get mouse move listener functionality back.
